### PR TITLE
Add a fromArray() helper to the formatter options

### DIFF
--- a/src/FormatterOptions.php
+++ b/src/FormatterOptions.php
@@ -18,6 +18,51 @@ class FormatterOptions
 
     private bool $shouldHighlight = false;
 
+    /**
+     * @param array{
+     *     crop_length?: int,
+     *     crop_marker?: string,
+     *     enable_crop?: bool,
+     *     enable_highlight?: bool,
+     *     highlight_start_tag?: string,
+     *     highlight_end_tag?: string
+     * } $options
+     */
+    public static function fromArray(array $options): self
+    {
+        $formatterOptions = new self();
+
+        if (isset($options['crop_length'])) {
+            $formatterOptions = $formatterOptions->withCropLength((int) $options['crop_length']);
+        }
+
+        if (isset($options['crop_marker'])) {
+            $formatterOptions = $formatterOptions->withCropMarker($options['crop_marker']);
+        }
+
+        if (\array_key_exists('enable_crop', $options)) {
+            $formatterOptions = $options['enable_crop']
+                ? $formatterOptions->withEnableCrop()
+                : $formatterOptions->withDisableCrop();
+        }
+
+        if (\array_key_exists('enable_highlight', $options)) {
+            $formatterOptions = $options['enable_highlight']
+                ? $formatterOptions->withEnableHighlight()
+                : $formatterOptions->withDisableHighlight();
+        }
+
+        if (isset($options['highlight_start_tag'])) {
+            $formatterOptions = $formatterOptions->withHighlightStartTag($options['highlight_start_tag']);
+        }
+
+        if (isset($options['highlight_end_tag'])) {
+            $formatterOptions = $formatterOptions->withHighlightEndTag($options['highlight_end_tag']);
+        }
+
+        return $formatterOptions;
+    }
+
     public function getCropLength(): int
     {
         return $this->cropLength;

--- a/tests/FormatterOptionsTest.php
+++ b/tests/FormatterOptionsTest.php
@@ -21,6 +21,48 @@ final class FormatterOptionsTest extends TestCase
         $this->assertEquals('</em>', $options->getHighlightEndTag());
     }
 
+    public function testFromArrayWithCustomValues(): void
+    {
+        $options = FormatterOptions::fromArray([
+            'crop_length' => 20,
+            'crop_marker' => '...',
+            'enable_crop' => true,
+            'enable_highlight' => true,
+            'highlight_start_tag' => '<strong>',
+            'highlight_end_tag' => '</strong>',
+        ]);
+
+        $this->assertEquals(20, $options->getCropLength());
+        $this->assertEquals('...', $options->getCropMarker());
+        $this->assertTrue($options->shouldCrop());
+        $this->assertTrue($options->shouldHighlight());
+        $this->assertEquals('<strong>', $options->getHighlightStartTag());
+        $this->assertEquals('</strong>', $options->getHighlightEndTag());
+    }
+
+    public function testFromArrayWithDefaults(): void
+    {
+        $options = FormatterOptions::fromArray([]);
+
+        $this->assertEquals(50, $options->getCropLength());
+        $this->assertEquals('…', $options->getCropMarker());
+        $this->assertFalse($options->shouldCrop());
+        $this->assertFalse($options->shouldHighlight());
+        $this->assertEquals('<em>', $options->getHighlightStartTag());
+        $this->assertEquals('</em>', $options->getHighlightEndTag());
+    }
+
+    public function testFromArrayWithDisablingOptions(): void
+    {
+        $options = FormatterOptions::fromArray([
+            'enable_crop' => false,
+            'enable_highlight' => false,
+        ]);
+
+        $this->assertFalse($options->shouldCrop());
+        $this->assertFalse($options->shouldHighlight());
+    }
+
     public function testWithCropLength(): void
     {
         $options = new FormatterOptions();


### PR DESCRIPTION
I was about to integrate the formatter as a Twig function in my project and I noticed that it's hard to create the options as an object from that context. So why not add a helper method to create the config from an array 😊 