### PR TITLE
Allow standalone use of Cropper

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,19 @@ $result = $formatter->format('This is my original text which I want to query.', 
 
 echo 'This is the formatted result: ' . $result->getFormattedText();
 ```
+
+### Cropping pre-highlighted results
+
+Sometimes, you have a pre-highlighted text that needs cropping (e.g. because your search engine supports highlighting
+but not context cropping), you can use the `Cropper` formatter directly in this case:
+
+```php
+$cropper = new \Loupe\Matcher\Formatting\Cropper(
+    $cropLength = 10,
+    $cropMarker = '…',
+    $highlightStartTag = '<em>',
+    $highlightStartTag = '</em>',
+);
+
+echo $cropper->cropHighlightedText('This is a <em>test</em> string.'); // Outputs: …a <em>test</em> st…
+```

--- a/src/Formatting/Cropper.php
+++ b/src/Formatting/Cropper.php
@@ -17,9 +17,9 @@ class Cropper implements Transformer
     ) {
     }
 
-    public function transform(string $text, TokenCollection $matches): string
+    public function cropHighlightedText(string $text): string
     {
-        if (!$text || !$matches->count() || $this->cropLength <= 0) {
+        if (!$text || $this->cropLength <= 0) {
             return $text;
         }
 
@@ -95,9 +95,16 @@ class Cropper implements Transformer
         }
 
         // Remove duplicate crop markers
-        $result = str_replace($this->cropMarker . $this->cropMarker, $this->cropMarker, $result);
+        return str_replace($this->cropMarker . $this->cropMarker, $this->cropMarker, $result);
+    }
 
-        return $result;
+    public function transform(string $text, TokenCollection $matches): string
+    {
+        if (!$matches->count()) {
+            return $text;
+        }
+
+        return $this->cropHighlightedText($text);
     }
 
     private function closestWordBoundary(string $string, int $position, bool $forward = true): int

--- a/tests/Formatting/CropperTest.php
+++ b/tests/Formatting/CropperTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Formatting;
+
+use Loupe\Matcher\Formatting\Cropper;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class CropperTest extends TestCase
+{
+    public static function cropHighlightedTextProvider(): \Generator
+    {
+        yield 'Cropping with too much context and no change' => [
+            'A wonderful serenity has <em>taken</em> possession of my entire soul, like these sweet mornings have <em>taken</em> all spring.',
+            'A wonderful serenity has <em>taken</em> possession of my entire soul, like these sweet mornings have <em>taken</em> all spring.',
+        ];
+
+        yield 'Cropping with less context and change' => [
+            'A wonderful serenity has <em>taken</em> possession of my entire soul, like these sweet mornings have <em>taken</em> all spring.',
+            '…serenity has <em>taken</em> possession…mornings have <em>taken</em> all spring…',
+            25,
+        ];
+
+        yield 'Cropping around single term in center' => [
+            'A wonderful serenity has taken possession of my entire <em>soul</em>, like these sweet mornings have taken all spring.',
+            '…serenity has taken possession of my entire <em>soul</em>, like these sweet mornings have taken…',
+        ];
+
+        yield 'Cropping around repeating term' => [
+            'A wonderful serenity has taken possession of my entire <em>soul</em>, like these sweet mornings of spring which I enjoy with my whole <em>soul</em>. I am alone, and feel the charm of existence in this spot, which was created for the bliss of a <em>soul</em> like mine.',
+            '…serenity has taken possession of my entire <em>soul</em>, like these sweet mornings of spring which I enjoy with my whole <em>soul</em>. I am alone, and feel the charm of existence…which was created for the bliss of a <em>soul</em> like mine.',
+        ];
+
+        yield 'Cropping around multiple terms' => [
+            'A wonderful serenity has taken possession of my entire <em>soul</em>, like these sweet mornings of spring which I enjoy with my whole being. I am alone, and feel the charm of existence in this spot, which was created for the <em>bliss</em> of a heart like mine.',
+            '…serenity has taken possession of my entire <em>soul</em>, like these sweet mornings of spring…this spot, which was created for the <em>bliss</em> of a heart like mine.',
+        ];
+
+        yield 'Cropping at start' => [
+            '<em>Wonderful</em> serenity has taken possession of my entire soul, like these sweet mornings of spring which I enjoy with my whole soul.',
+            '<em>Wonderful</em> serenity has taken possession of…',
+        ];
+
+        yield 'Cropping at end' => [
+            'Wonderful serenity has taken possession of my entire soul, like these sweet mornings of spring which I enjoy with my whole <em>panorama</em>.',
+            '…spring which I enjoy with my whole <em>panorama</em>.',
+        ];
+
+        yield 'Cropping with custom length' => [
+            'Wonderful serenity has taken possession of my <em>entire</em> soul, like these sweet mornings of spring which I enjoy with my <em>whole</em> panorama.',
+            '…my <em>entire</em> soul…with my <em>whole</em> pano…',
+            15,
+        ];
+
+        yield 'Cropping with custom marker' => [
+            'Wonderful serenity has taken possession of my <em>entire</em> soul, like these sweet mornings of spring which I enjoy with my <em>whole</em> panorama.',
+            ' --- possession of my <em>entire</em> soul, like --- enjoy with my <em>whole</em> panorama.',
+            25,
+            ' --- ',
+        ];
+
+        yield 'Cropping with custom highlight tags' => [
+            'Wonderful serenity has taken <mark>possession</mark> of my <em>entire</em> soul, like these sweet mornings of <mark>spring</mark> which I enjoy with my <em>whole</em> panorama.',
+            '…taken <mark>possession</mark> of my <em>entire</em>…mornings of <mark>spring</mark> which I enjoy…',
+            25,
+            '…',
+            '<mark>',
+            '</mark>',
+        ];
+    }
+
+    #[DataProvider('cropHighlightedTextProvider')]
+    public function testCropHighlightedText(string $highlightedText, string $expectedResult, int $cropLength = 50, string $cropMarker = '…', string $highlightStartTag = '<em>', string $highlightEndTag = '</em>'): void
+    {
+        $cropper = new Cropper($cropLength, $cropMarker, $highlightStartTag, $highlightEndTag);
+
+        $this->assertSame($expectedResult, $cropper->cropHighlightedText($highlightedText));
+    }
+}


### PR DESCRIPTION
Right now you have to combine the matcher/tokenizer with the cropper - using it standalone is not an option yet (you could by providing a nonsense `TokenCollection` with a placeholder term in it but that doesn't feel like an official API).

However, if you have a search engine that supports highlighting but no cropping, you may want to use the cropper standalone and rely on the highlights provided by the search engine (as otherwise matches from the search engine do not match the ones of `loupe/matcher`).

Here we go, standalone usage of the `Cropper`, documented and tested 😇 