### PR TITLE
Separate stopwords from tokens

### DIFF
--- a/src/FormatterResult.php
+++ b/src/FormatterResult.php
@@ -26,14 +26,13 @@ class FormatterResult
     }
 
     /**
-     * @return array<int, array{start: int, length: int, stopword: bool}>
+     * @return array<int, array{start: int, length: int}>
      */
     public function getMatchesArray(): array
     {
         return array_map(fn (Token $token) => [
             'start' => $token->getStartPosition(),
             'length' => $token->getLength(),
-            'stopword' => $token->isStopWord(),
         ], $this->matches->all());
     }
 

--- a/src/Matcher.php
+++ b/src/Matcher.php
@@ -14,6 +14,9 @@ class Matcher
 {
     private StopWordsInterface $stopWords;
 
+    /**
+     * @param StopWordsInterface|array<string> $stopWords
+     */
     public function __construct(
         private TokenizerInterface $tokenizer,
         StopWordsInterface|array $stopWords = []

--- a/src/Matcher.php
+++ b/src/Matcher.php
@@ -43,15 +43,8 @@ class Matcher
     /**
      * @return Span[]
      */
-    public function calculateMatchSpans(TokenCollection $text, TokenCollection $matches): array
+    public function calculateMatchSpans(TokenCollection $matches): array
     {
-        foreach ($text->all() as $textToken) {
-            // TODO: check if $textToken is a match (part of $matches with the correct position)
-            // If not, check if previous token was a match and this is a stopword etc.:
-           // if ($this->stopWords->isStopWord($textToken)) {
-        }
-
-
         $matches = $this->removeSolitaryStopWords($matches);
 
         $spans = [];
@@ -80,7 +73,7 @@ class Matcher
         $result = new TokenCollection();
 
         foreach ($matches->all() as $i => $match) {
-            if (!$match->isStopWord()) {
+            if (!$this->stopWords->isStopWord($match)) {
                 $result->add($match);
                 continue;
             }
@@ -92,8 +85,8 @@ class Matcher
                 $nextMatch = $matches->atIndex($i + $j);
 
                 // Keep stopword matches between non-stopword matches of interest
-                $hasNonStopWordNeighbor = ($prevMatch && !$prevMatch->isStopWord() && $prevMatch->getEndPosition() >= $match->getStartPosition() - $maxCharDistance)
-                    || ($nextMatch && !$nextMatch->isStopWord() && $nextMatch->getStartPosition() <= $match->getEndPosition() + $maxCharDistance);
+                $hasNonStopWordNeighbor = ($prevMatch && !$this->stopWords->isStopWord($prevMatch) && $prevMatch->getEndPosition() >= $match->getStartPosition() - $maxCharDistance)
+                    || ($nextMatch && !$this->stopWords->isStopWord($nextMatch) && $nextMatch->getStartPosition() <= $match->getEndPosition() + $maxCharDistance);
 
                 if ($hasNonStopWordNeighbor) {
                     break;

--- a/src/Matcher.php
+++ b/src/Matcher.php
@@ -4,19 +4,21 @@ declare(strict_types=1);
 
 namespace Loupe\Matcher;
 
+use Loupe\Matcher\StopWords\InMemoryStopWords;
+use Loupe\Matcher\StopWords\StopWordsInterface;
 use Loupe\Matcher\Tokenizer\Span;
 use Loupe\Matcher\Tokenizer\TokenCollection;
 use Loupe\Matcher\Tokenizer\TokenizerInterface;
 
 class Matcher
 {
-    /**
-     * @param array<string> $stopWords
-     */
+    private StopWordsInterface $stopWords;
+
     public function __construct(
         private TokenizerInterface $tokenizer,
-        private array $stopWords = []
+        StopWordsInterface|array $stopWords = []
     ) {
+        $this->stopWords = $stopWords instanceof StopWordsInterface ? $stopWords : new InMemoryStopWords($stopWords);
     }
 
     public function calculateMatches(TokenCollection|string $text, TokenCollection|string $query): TokenCollection
@@ -25,7 +27,7 @@ class Matcher
             return new TokenCollection();
         }
 
-        $textTokens = $text instanceof TokenCollection ? $text : $this->tokenizer->tokenize($text, stopWords: $this->stopWords, includeStopWords: true);
+        $textTokens = $text instanceof TokenCollection ? $text : $this->tokenizer->tokenize($text);
         $queryTokens = $query instanceof TokenCollection ? $query : $this->tokenizer->tokenize($query);
 
         $matches = new TokenCollection();
@@ -41,8 +43,15 @@ class Matcher
     /**
      * @return Span[]
      */
-    public function calculateMatchSpans(TokenCollection $matches): array
+    public function calculateMatchSpans(TokenCollection $text, TokenCollection $matches): array
     {
+        foreach ($text->all() as $textToken) {
+            // TODO: check if $textToken is a match (part of $matches with the correct position)
+            // If not, check if previous token was a match and this is a stopword etc.:
+           // if ($this->stopWords->isStopWord($textToken)) {
+        }
+
+
         $matches = $this->removeSolitaryStopWords($matches);
 
         $spans = [];

--- a/src/StopWords/InMemoryStopWords.php
+++ b/src/StopWords/InMemoryStopWords.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Loupe\Matcher\StopWords;
+
+use Loupe\Matcher\Tokenizer\Token;
+
+class InMemoryStopWords implements StopWordsInterface
+{
+    public function __construct(private array $stopWords = [])
+    {
+
+    }
+
+    public function isStopWord(Token $token): bool
+    {
+        return \in_array($token->getTerm(), $this->stopWords, true);
+    }
+}

--- a/src/StopWords/InMemoryStopWords.php
+++ b/src/StopWords/InMemoryStopWords.php
@@ -8,6 +8,9 @@ use Loupe\Matcher\Tokenizer\Token;
 
 class InMemoryStopWords implements StopWordsInterface
 {
+    /**
+     * @param array<string> $stopWords
+     */
     public function __construct(
         private array $stopWords = []
     ) {

--- a/src/StopWords/InMemoryStopWords.php
+++ b/src/StopWords/InMemoryStopWords.php
@@ -1,13 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Loupe\Matcher\StopWords;
 
 use Loupe\Matcher\Tokenizer\Token;
 
 class InMemoryStopWords implements StopWordsInterface
 {
-    public function __construct(private array $stopWords = [])
-    {
+    public function __construct(
+        private array $stopWords = []
+    ) {
 
     }
 

--- a/src/StopWords/StopWordsInterface.php
+++ b/src/StopWords/StopWordsInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Loupe\Matcher\StopWords;
+
+use Loupe\Matcher\Tokenizer\Token;
+
+interface StopWordsInterface
+{
+    public function isStopWord(Token $token): bool;
+}

--- a/src/StopWords/StopWordsInterface.php
+++ b/src/StopWords/StopWordsInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Loupe\Matcher\StopWords;
 
 use Loupe\Matcher\Tokenizer\Token;

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -42,6 +42,13 @@ class Token
         return array_unique(array_merge([$this->getTerm()], $this->getVariants()));
     }
 
+    public function equals(Token $token): bool
+    {
+        return $this->getTerm() === $token->getTerm()
+            && $this->getStartPosition() === $token->getStartPosition()
+            && $this->getLength() === $token->getLength();
+    }
+
     public function getEndPosition(): int
     {
         return $this->startPosition + $this->length;

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -19,7 +19,6 @@ class Token
         private int $startPosition,
         private bool $isPartOfPhrase,
         private bool $isNegated,
-        private bool $isStopWord,
     ) {
         $this->length = mb_strlen($this->term, 'UTF-8');
     }
@@ -104,18 +103,6 @@ class Token
     public function isPartOfPhrase(): bool
     {
         return $this->isPartOfPhrase;
-    }
-
-    public function isStopWord(): bool
-    {
-        return $this->isStopWord;
-    }
-
-    public function withMarkAsStopWord(): self
-    {
-        $clone = clone $this;
-        $clone->isStopWord = true;
-        return $clone;
     }
 
     /**

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -42,7 +42,7 @@ class Token
         return array_unique(array_merge([$this->getTerm()], $this->getVariants()));
     }
 
-    public function equals(Token $token): bool
+    public function equals(self $token): bool
     {
         return $this->getTerm() === $token->getTerm()
             && $this->getStartPosition() === $token->getStartPosition()

--- a/src/Tokenizer/TokenCollection.php
+++ b/src/Tokenizer/TokenCollection.php
@@ -105,6 +105,17 @@ class TokenCollection implements \Countable
         return $this->tokens[$index] ?? null;
     }
 
+    public function contains(Token $token): bool
+    {
+        foreach ($this->all() as $t) {
+            if ($t->equals($token)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public function count(): int
     {
         return \count($this->tokens);

--- a/src/Tokenizer/Tokenizer.php
+++ b/src/Tokenizer/Tokenizer.php
@@ -25,15 +25,11 @@ class Tokenizer implements TokenizerInterface
         return false;
     }
 
-    /**
-     * @param array<string> $stopWords
-     */
-    public function tokenize(string $string, ?int $maxTokens = null, array $stopWords = [], bool $includeStopWords = false): TokenCollection
+    public function tokenize(string $string, ?int $maxTokens = null): TokenCollection
     {
         $iterator = \IntlRuleBasedBreakIterator::createWordInstance($this->locale); // @phpstan-ignore-line - null is allowed
         $iterator->setText($string);
 
-        $all = new TokenCollection();
         $tokens = new TokenCollection();
         $id = 0;
         $position = 0;
@@ -72,7 +68,6 @@ class Tokenizer implements TokenizerInterface
             }
 
             $term = mb_strtolower($term, 'UTF-8');
-            $stopword = \in_array($term, $stopWords, true);
 
             $token = new Token(
                 $id++,
@@ -80,25 +75,13 @@ class Tokenizer implements TokenizerInterface
                 $position,
                 $phrase,
                 $negated,
-                $stopword
             );
 
             $position += $token->getLength();
-
-            // Collect all tokens regardless of stop word status
-            $all->add($token);
-
-            // Skip stop words
-            if ($stopword && !$includeStopWords) {
-                continue;
-            }
-
-            // Only add non-stop words to the result
             $tokens->add($token);
         }
 
-        // If removing stop words resulted in an empty collection, return all tokens
-        return $tokens->empty() ? $all : $tokens;
+        return $tokens;
     }
 
     private function isWhitespace(?int $status, string $token): bool

--- a/src/Tokenizer/TokenizerInterface.php
+++ b/src/Tokenizer/TokenizerInterface.php
@@ -8,8 +8,5 @@ interface TokenizerInterface
 {
     public function matches(Token $token, TokenCollection $tokens): bool;
 
-    /**
-     * @param array<string> $stopWords
-     */
-    public function tokenize(string $string, ?int $maxTokens = null, array $stopWords = [], bool $includeStopWords = false): TokenCollection;
+    public function tokenize(string $string, ?int $maxTokens = null): TokenCollection;
 }

--- a/tests/FormatterResultTest.php
+++ b/tests/FormatterResultTest.php
@@ -30,43 +30,21 @@ final class FormatterResultTest extends TestCase
 
     public function testMatchesArray(): void
     {
-        $matches = (new Tokenizer())->tokenize('foo bar baz', stopWords: ['bar']);
+        $matches = (new Tokenizer())->tokenize('foo bar baz');
         $result = new FormatterResult('text', $matches);
 
         $this->assertEquals([
             [
                 'start' => 0,
                 'length' => 3,
-                'stopword' => false,
-            ],
-            [
-                'start' => 8,
-                'length' => 3,
-                'stopword' => false,
-            ],
-        ], $result->getMatchesArray());
-    }
-
-    public function testStopwordMatchesArray(): void
-    {
-        $matches = (new Tokenizer())->tokenize('foo bar baz', stopWords: ['bar'], includeStopWords: true);
-        $result = new FormatterResult('text', $matches);
-
-        $this->assertEquals([
-            [
-                'start' => 0,
-                'length' => 3,
-                'stopword' => false,
             ],
             [
                 'start' => 4,
                 'length' => 3,
-                'stopword' => true,
             ],
             [
                 'start' => 8,
                 'length' => 3,
-                'stopword' => false,
             ],
         ], $result->getMatchesArray());
     }

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -22,14 +22,14 @@ class FormatterTest extends TestCase
     /**
      * @var array<string>
      */
-    private array $stopwords;
+    private array $stopWords;
 
     protected function setUp(): void
     {
         $tokenizer = new Tokenizer();
 
-        $this->stopwords = ['a', 'of', 'the'];
-        $this->matcher = new Matcher($tokenizer, stopWords: $this->stopwords);
+        $this->stopWords = ['a', 'of', 'the'];
+        $this->matcher = new Matcher($tokenizer, stopWords: $this->stopWords);
         $this->queryTerms = $tokenizer->tokenize('test');
     }
 
@@ -214,9 +214,7 @@ class FormatterTest extends TestCase
             $options = $options->withDisableCrop();
         }
 
-        $query = $query instanceof TokenCollection
-            ? $query
-            : (new Tokenizer())->tokenize($query, stopWords: $this->stopwords, includeStopWords: true);
+        $query = $query instanceof TokenCollection ? $query : (new Tokenizer())->tokenize($query);
 
         $formatter = new Formatter($this->matcher);
         $result = $formatter->format($text, $query, $options);
@@ -297,9 +295,7 @@ class FormatterTest extends TestCase
             $options = $options->withDisableHighlight();
         }
 
-        $query = $query instanceof TokenCollection
-            ? $query
-            : (new Tokenizer())->tokenize($query, stopWords: $this->stopwords, includeStopWords: true);
+        $query = $query instanceof TokenCollection ? $query : (new Tokenizer())->tokenize($query);
 
         $formatter = new Formatter($this->matcher);
         $result = $formatter->format($text, $query, $options);

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -174,9 +174,9 @@ class FormatterTest extends TestCase
         yield 'Highlighting with token variants' => [
             new TokenCollection(
                 [
-                    (new Token(0, 'my', 0, false, false, false)),
-                    (new Token(1, 'wonder', 3, false, false, false))->withVariants(['wonders']),
-                    (new Token(2, 'soul', 10, false, false, false))->withVariants(['souls']),
+                    (new Token(0, 'my', 0, false, false)),
+                    (new Token(1, 'wonder', 3, false, false))->withVariants(['wonders']),
+                    (new Token(2, 'soul', 10, false, false))->withVariants(['souls']),
                 ],
             ),
             'A wonder of wonders has taken possession of my entire soul, like some souls\' mornings of spring.',

--- a/tests/MatcherTest.php
+++ b/tests/MatcherTest.php
@@ -22,15 +22,15 @@ final class MatcherTest extends TestCase
 
     public function testCalculateMatchSpansMergesAdjacentTokens(): void
     {
-        $text = 'quick brown fox';
+        $text = 'awfully quick brown fox sighted';
         $query = 'quick brown fox';
 
         $matches = $this->matcher->calculateMatches($text, $query);
         $spans = $this->matcher->calculateMatchSpans($matches);
 
         $this->assertCount(1, $spans);
-        $this->assertSame(0, $spans[0]->getStartPosition());
-        $this->assertSame(15, $spans[0]->getEndPosition());
+        $this->assertSame(8, $spans[0]->getStartPosition());
+        $this->assertSame(23, $spans[0]->getEndPosition());
         $this->assertSame(15, $spans[0]->getLength());
     }
 
@@ -58,7 +58,7 @@ final class MatcherTest extends TestCase
     public function testStopWordsAloneDoNotCreateSpan(): void
     {
         $text = 'the is at which on';
-        $query = 'the is at';
+        $query = 'is at';
         $matches = $this->matcher->calculateMatches($text, $query);
         $spans = $this->matcher->calculateMatchSpans($matches);
 
@@ -67,8 +67,8 @@ final class MatcherTest extends TestCase
 
     public function testStopWordsAmongQueryTermsAreIncluded(): void
     {
-        $text = 'quick the fox';
-        $query = 'quick the fox';
+        $text = 'another quick fox in sight now';
+        $query = 'quick fox in sight';
 
         $matches = $this->matcher->calculateMatches($text, $query);
         $spans = $this->matcher->calculateMatchSpans($matches);
@@ -78,20 +78,20 @@ final class MatcherTest extends TestCase
 
     public function testStopWordsAroundQueryTermsAreIncluded(): void
     {
-        $text = 'the quick fox is';
+        $text = 'checking if the quick fox is visible';
         $query = 'the quick fox is';
 
         $matches = $this->matcher->calculateMatches($text, $query);
         $spans = $this->matcher->calculateMatchSpans($matches);
 
         $this->assertCount(1, $spans);
-        $this->assertSame(0, $spans[0]->getStartPosition());
-        $this->assertSame(16, $spans[0]->getEndPosition());
+        $this->assertSame(12, $spans[0]->getStartPosition());
+        $this->assertSame(28, $spans[0]->getEndPosition());
     }
 
     public function testStopWordsBetweenQueryTermsAreNotIncluded(): void
     {
-        $text = 'quick the fox';
+        $text = 'maybe the fox is quick and brown';
         $query = 'quick fox';
 
         $matches = $this->matcher->calculateMatches($text, $query);

--- a/tests/Tokenizer/TokenizerTest.php
+++ b/tests/Tokenizer/TokenizerTest.php
@@ -137,44 +137,6 @@ class TokenizerTest extends TestCase
         ], $tokens->allNegatedTermsWithVariants());
     }
 
-    public function testStopWords(): void
-    {
-        $tokenizer = new Tokenizer();
-        $tokens = $tokenizer->tokenize(
-            'Hallo, mein Name ist Hase und ich weiß von nichts.',
-            stopWords: ['ist', 'und', 'von']
-        );
-
-        $this->assertSame([
-            'hallo',
-            'mein',
-            'name',
-            'hase',
-            'ich',
-            'weiß',
-            'nichts',
-        ], $tokens->allTermsWithVariants());
-    }
-
-    public function testStopWordsOnly(): void
-    {
-        $tokenizer = new Tokenizer();
-
-        $tokensWithStopWords = $tokenizer->tokenize(
-            'ist nicht seltsam',
-            stopWords: ['ist', 'nicht']
-        );
-
-        $this->assertSame(['seltsam'], $tokensWithStopWords->allTermsWithVariants());
-
-        $tokensWithStopWordsOnly = $tokenizer->tokenize(
-            'ist oder nicht',
-            stopWords: ['ist', 'oder', 'nicht']
-        );
-
-        $this->assertSame(['ist', 'oder', 'nicht'], $tokensWithStopWordsOnly->allTermsWithVariants());
-    }
-
     public function testTokenizeWithPhrases(): void
     {
         $tokenizer = new Tokenizer();


### PR DESCRIPTION
- Building on #10 
- Remove stopword flag from `Token`
- Pass stopwords into `Matcher`
