### PR TITLE
Calculate token length before normalization

### DIFF
--- a/src/Matcher.php
+++ b/src/Matcher.php
@@ -78,10 +78,10 @@ class Matcher
 
             if ($currentSpan) {
                 // Extend the current span
-                $currentSpan = $currentSpan->withEndPosition($textToken->getEndPosition());
+                $currentSpan = $currentSpan->withEndPosition($textToken->getOriginalEndPosition());
             } else {
                 // Start a new span
-                $currentSpan = new Span($textToken->getStartPosition(), $textToken->getEndPosition());
+                $currentSpan = new Span($textToken->getOriginalStartPosition(), $textToken->getOriginalEndPosition());
             }
         }
 

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -10,6 +10,8 @@ class Token
 
     private int $originalLength;
 
+    private int $originalStartPosition;
+
     /**
      * @var array<string>
      */
@@ -21,10 +23,12 @@ class Token
         private int $startPosition,
         private bool $isPartOfPhrase,
         private bool $isNegated,
+        ?int $originalStartPosition = null,
         ?int $originalLength = null,
     ) {
         $this->length = mb_strlen($this->term, 'UTF-8');
         $this->originalLength = $originalLength ?? $this->length;
+        $this->originalStartPosition = $originalStartPosition ?? $this->startPosition;
     }
 
     /**
@@ -61,9 +65,19 @@ class Token
         return $this->length;
     }
 
+    public function getOriginalEndPosition(): int
+    {
+        return $this->originalStartPosition + $this->originalLength;
+    }
+
     public function getOriginalLength(): int
     {
         return $this->originalLength;
+    }
+
+    public function getOriginalStartPosition(): int
+    {
+        return $this->originalStartPosition;
     }
 
     public function getStartPosition(): int

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -19,8 +19,9 @@ class Token
         private int $startPosition,
         private bool $isPartOfPhrase,
         private bool $isNegated,
+        ?int $originalLength = null,
     ) {
-        $this->length = mb_strlen($this->term, 'UTF-8');
+        $this->length = $originalLength ?? mb_strlen($this->term, 'UTF-8');
     }
 
     /**

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -8,6 +8,8 @@ class Token
 {
     private int $length;
 
+    private int $originalLength;
+
     /**
      * @var array<string>
      */
@@ -21,7 +23,8 @@ class Token
         private bool $isNegated,
         ?int $originalLength = null,
     ) {
-        $this->length = $originalLength ?? mb_strlen($this->term, 'UTF-8');
+        $this->length = mb_strlen($this->term, 'UTF-8');
+        $this->originalLength = $originalLength ?? $this->length;
     }
 
     /**
@@ -56,6 +59,11 @@ class Token
     public function getLength(): int
     {
         return $this->length;
+    }
+
+    public function getOriginalLength(): int
+    {
+        return $this->originalLength;
     }
 
     public function getStartPosition(): int

--- a/src/Tokenizer/Tokenizer.php
+++ b/src/Tokenizer/Tokenizer.php
@@ -60,6 +60,7 @@ class Tokenizer implements TokenizerInterface
         $tokens = new TokenCollection();
         $id = 0;
         $position = 0;
+        $originalPosition = 0;
         $phrase = false;
         $negated = false;
         $whitespace = true;
@@ -85,8 +86,11 @@ class Tokenizer implements TokenizerInterface
             $word = $this->isWord($status);
             $whitespace = $this->isWhitespace($status, $term);
 
+            $originalLength = mb_strlen($term, 'UTF-8');
+
             if (!$word) {
-                $position += mb_strlen($term, 'UTF-8');
+                $position += $originalLength;
+                $originalPosition += $originalLength;
                 continue;
             }
 
@@ -94,7 +98,6 @@ class Tokenizer implements TokenizerInterface
                 break;
             }
 
-            $originalLength = mb_strlen($term, 'UTF-8');
             $term = $this->normalizer->normalize($term);
 
             $token = new Token(
@@ -103,6 +106,7 @@ class Tokenizer implements TokenizerInterface
                 $position,
                 $phrase,
                 $negated,
+                $originalPosition,
                 $originalLength,
             );
 
@@ -111,6 +115,7 @@ class Tokenizer implements TokenizerInterface
             }
 
             $position += $token->getLength();
+            $originalPosition += $originalLength;
             $tokens->add($token);
         }
 

--- a/src/Tokenizer/Tokenizer.php
+++ b/src/Tokenizer/Tokenizer.php
@@ -94,6 +94,7 @@ class Tokenizer implements TokenizerInterface
                 break;
             }
 
+            $originalLength = mb_strlen($term, 'UTF-8');
             $term = $this->normalizer->normalize($term);
 
             $token = new Token(
@@ -102,6 +103,7 @@ class Tokenizer implements TokenizerInterface
                 $position,
                 $phrase,
                 $negated,
+                $originalLength,
             );
 
             if ($withVariants && $this->localeConfiguration !== null) {

--- a/tests/MatcherTest.php
+++ b/tests/MatcherTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Loupe\Matcher\Tests;
 
 use Loupe\Matcher\Matcher;
+use Loupe\Matcher\Tokenizer\LocaleConfiguration\German;
 use Loupe\Matcher\Tokenizer\TokenCollection;
 use Loupe\Matcher\Tokenizer\Tokenizer;
 use PHPUnit\Framework\TestCase;
@@ -110,5 +111,23 @@ final class MatcherTest extends TestCase
         $words = array_map(fn ($t) => $t->getTerm(), $matches->all());
 
         $this->assertNotContains('the', $words);
+    }
+
+    public function testDecompositionKeepsCorrectPositions(): void
+    {
+        $text = 'das grosse kuenstlerinnengespraech war fuer die silvesternacht geplant';
+        $query = 'gespraech nacht';
+
+        $tokenizer = new Tokenizer(new German());
+        $matcher = new Matcher($tokenizer);
+        $matches = $matcher->calculateMatches($text, $query);
+        $spans = $matcher->calculateMatchSpans($text, $query, $matches);
+
+        $this->assertEquals(2, \count($matches->all()));
+        $this->assertSame([11, 34], [$spans[0]->getStartPosition(), $spans[0]->getEndPosition()]);
+        $this->assertSame([48, 62], [$spans[1]->getStartPosition(), $spans[1]->getEndPosition()]);
+
+        $words = array_map(fn ($t) => $t->getTerm(), $matches->all());
+        $this->assertEquals(['kuenstlerinnengespraech', 'silvesternacht'], $words);
     }
 }

--- a/tests/MatcherTest.php
+++ b/tests/MatcherTest.php
@@ -130,4 +130,19 @@ final class MatcherTest extends TestCase
         $words = array_map(fn ($t) => $t->getTerm(), $matches->all());
         $this->assertEquals(['kuenstlerinnengespraech', 'silvesternacht'], $words);
     }
+
+    public function testNormalizationKeepsCorrectPositions(): void
+    {
+        $text = 'Das große Künstlerinnengespräch war für die Silvesternacht geplant';
+        $query = 'gespräch nacht';
+
+        $tokenizer = new Tokenizer(new German());
+        $matcher = new Matcher($tokenizer);
+        $matches = $matcher->calculateMatches($text, $query);
+        $spans = $matcher->calculateMatchSpans($text, $query, $matches);
+
+        $this->assertEquals(2, \count($matches->all()));
+        $this->assertSame([10, 31], [$spans[0]->getStartPosition(), $spans[0]->getEndPosition()]);
+        $this->assertSame([44, 58], [$spans[1]->getStartPosition(), $spans[1]->getEndPosition()]);
+    }
 }

--- a/tests/MatcherTest.php
+++ b/tests/MatcherTest.php
@@ -35,11 +35,44 @@ final class MatcherTest extends TestCase
         $this->assertSame(15, $spans[0]->getLength());
     }
 
+    public function testDecompositionKeepsCorrectPositions(): void
+    {
+        $text = 'das grosse kuenstlerinnengespraech war fuer die silvesternacht geplant';
+        $query = 'gespraech nacht';
+
+        $tokenizer = new Tokenizer(new German());
+        $matcher = new Matcher($tokenizer);
+        $matches = $matcher->calculateMatches($text, $query);
+        $spans = $matcher->calculateMatchSpans($text, $query, $matches);
+
+        $this->assertEquals(2, \count($matches->all()));
+        $this->assertSame([11, 34], [$spans[0]->getStartPosition(), $spans[0]->getEndPosition()]);
+        $this->assertSame([48, 62], [$spans[1]->getStartPosition(), $spans[1]->getEndPosition()]);
+
+        $words = array_map(fn ($t) => $t->getTerm(), $matches->all());
+        $this->assertEquals(['kuenstlerinnengespraech', 'silvesternacht'], $words);
+    }
+
     public function testEmptyTextReturnsEmptyCollection(): void
     {
         $result = $this->matcher->calculateMatches('', 'query');
         $this->assertInstanceOf(TokenCollection::class, $result);
         $this->assertCount(0, $result->all());
+    }
+
+    public function testNormalizationKeepsCorrectPositions(): void
+    {
+        $text = 'Das große Künstlerinnengespräch war für die Silvesternacht geplant';
+        $query = 'gespräch nacht';
+
+        $tokenizer = new Tokenizer(new German());
+        $matcher = new Matcher($tokenizer);
+        $matches = $matcher->calculateMatches($text, $query);
+        $spans = $matcher->calculateMatchSpans($text, $query, $matches);
+
+        $this->assertEquals(2, \count($matches->all()));
+        $this->assertSame([10, 31], [$spans[0]->getStartPosition(), $spans[0]->getEndPosition()]);
+        $this->assertSame([44, 58], [$spans[1]->getStartPosition(), $spans[1]->getEndPosition()]);
     }
 
     public function testSimpleMatch(): void
@@ -111,38 +144,5 @@ final class MatcherTest extends TestCase
         $words = array_map(fn ($t) => $t->getTerm(), $matches->all());
 
         $this->assertNotContains('the', $words);
-    }
-
-    public function testDecompositionKeepsCorrectPositions(): void
-    {
-        $text = 'das grosse kuenstlerinnengespraech war fuer die silvesternacht geplant';
-        $query = 'gespraech nacht';
-
-        $tokenizer = new Tokenizer(new German());
-        $matcher = new Matcher($tokenizer);
-        $matches = $matcher->calculateMatches($text, $query);
-        $spans = $matcher->calculateMatchSpans($text, $query, $matches);
-
-        $this->assertEquals(2, \count($matches->all()));
-        $this->assertSame([11, 34], [$spans[0]->getStartPosition(), $spans[0]->getEndPosition()]);
-        $this->assertSame([48, 62], [$spans[1]->getStartPosition(), $spans[1]->getEndPosition()]);
-
-        $words = array_map(fn ($t) => $t->getTerm(), $matches->all());
-        $this->assertEquals(['kuenstlerinnengespraech', 'silvesternacht'], $words);
-    }
-
-    public function testNormalizationKeepsCorrectPositions(): void
-    {
-        $text = 'Das große Künstlerinnengespräch war für die Silvesternacht geplant';
-        $query = 'gespräch nacht';
-
-        $tokenizer = new Tokenizer(new German());
-        $matcher = new Matcher($tokenizer);
-        $matches = $matcher->calculateMatches($text, $query);
-        $spans = $matcher->calculateMatchSpans($text, $query, $matches);
-
-        $this->assertEquals(2, \count($matches->all()));
-        $this->assertSame([10, 31], [$spans[0]->getStartPosition(), $spans[0]->getEndPosition()]);
-        $this->assertSame([44, 58], [$spans[1]->getStartPosition(), $spans[1]->getEndPosition()]);
     }
 }

--- a/tests/Tokenizer/TokenizerTest.php
+++ b/tests/Tokenizer/TokenizerTest.php
@@ -40,6 +40,8 @@ class TokenizerTest extends TestCase
     public function testGermanEszettNormalization(): void
     {
         $tokenizer = new Tokenizer();
+        $tokens = $tokenizer->tokenize('Die Straße ist neben dem größeren Gebäude.');
+
         // ß should normalize to ss
         $this->assertSame([
             'die',
@@ -49,8 +51,7 @@ class TokenizerTest extends TestCase
             'dem',
             'grosseren',
             'gebaude',
-        ], $tokenizer->tokenize('Die Straße ist neben dem größeren Gebäude.')
-            ->allTermsWithVariants());
+        ], $tokens->allTermsWithVariants());
     }
 
     public function testIcelandicSpecialCharacters(): void
@@ -209,6 +210,29 @@ class TokenizerTest extends TestCase
             'hase',
             'ich',
         ], $tokens->allNegatedTermsWithVariants());
+    }
+
+    public function testOriginalTermPositionAndLength(): void
+    {
+        $tokenizer = new Tokenizer();
+        $tokens = $tokenizer->tokenize('Die größere Straße ist lang.');
+
+        $this->assertSame([
+            'die',
+            'grossere',
+            'strasse',
+            'ist',
+            'lang',
+        ], $tokens->allTermsWithVariants());
+
+        // The original term length should be remembered even after normalization
+        $this->assertSame(13, $tokens->all()[2]->getStartPosition());
+        $this->assertSame(7, $tokens->all()[2]->getLength());
+        $this->assertSame(20, $tokens->all()[2]->getEndPosition());
+
+        $this->assertSame(12, $tokens->all()[2]->getOriginalStartPosition());
+        $this->assertSame(6, $tokens->all()[2]->getOriginalLength());
+        $this->assertSame(18, $tokens->all()[2]->getOriginalEndPosition());
     }
 
     public function testPolishLNormalization(): void


### PR DESCRIPTION
- Calculate the token length before any normalization happens on it
- Get the correct match positions for the original text
- They are currently off by the number of expanded unicode characters (ä → ae, ß → ss, etc)
- Added a test to make sure it isn't decompositon causing this
- Added a test that failed before and now passes