### PR TITLE
Remember original token positions for match span calculation

### DIFF
--- a/src/FormatterResult.php
+++ b/src/FormatterResult.php
@@ -31,8 +31,8 @@ class FormatterResult
     public function getMatchesArray(): array
     {
         return array_map(fn (Token $token) => [
-            'start' => $token->getStartPosition(),
-            'length' => $token->getLength(),
+            'start' => $token->getOriginalStartPosition(),
+            'length' => $token->getOriginalLength(),
         ], $this->matches->all());
     }
 

--- a/src/Matcher.php
+++ b/src/Matcher.php
@@ -78,10 +78,10 @@ class Matcher
 
             if ($currentSpan) {
                 // Extend the current span
-                $currentSpan = $currentSpan->withEndPosition($textToken->getEndPosition());
+                $currentSpan = $currentSpan->withEndPosition($textToken->getOriginalEndPosition());
             } else {
                 // Start a new span
-                $currentSpan = new Span($textToken->getStartPosition(), $textToken->getEndPosition());
+                $currentSpan = new Span($textToken->getOriginalStartPosition(), $textToken->getOriginalEndPosition());
             }
         }
 

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -8,6 +8,10 @@ class Token
 {
     private int $length;
 
+    private int $originalLength;
+
+    private int $originalStartPosition;
+
     /**
      * @var array<string>
      */
@@ -19,8 +23,12 @@ class Token
         private int $startPosition,
         private bool $isPartOfPhrase,
         private bool $isNegated,
+        ?int $originalStartPosition = null,
+        ?int $originalLength = null,
     ) {
         $this->length = mb_strlen($this->term, 'UTF-8');
+        $this->originalLength = $originalLength ?? $this->length;
+        $this->originalStartPosition = $originalStartPosition ?? $this->startPosition;
     }
 
     /**
@@ -55,6 +63,21 @@ class Token
     public function getLength(): int
     {
         return $this->length;
+    }
+
+    public function getOriginalEndPosition(): int
+    {
+        return $this->originalStartPosition + $this->originalLength;
+    }
+
+    public function getOriginalLength(): int
+    {
+        return $this->originalLength;
+    }
+
+    public function getOriginalStartPosition(): int
+    {
+        return $this->originalStartPosition;
     }
 
     public function getStartPosition(): int

--- a/src/Tokenizer/Tokenizer.php
+++ b/src/Tokenizer/Tokenizer.php
@@ -39,6 +39,7 @@ class Tokenizer implements TokenizerInterface
         $tokens = new TokenCollection();
         $id = 0;
         $position = 0;
+        $originalPosition = 0;
         $phrase = false;
         $negated = false;
         $whitespace = true;
@@ -64,8 +65,11 @@ class Tokenizer implements TokenizerInterface
             $word = $this->isWord($status);
             $whitespace = $this->isWhitespace($status, $term);
 
+            $originalLength = mb_strlen($term, 'UTF-8');
+
             if (!$word) {
-                $position += mb_strlen($term, 'UTF-8');
+                $position += $originalLength;
+                $originalPosition += $originalLength;
                 continue;
             }
 
@@ -90,9 +94,12 @@ class Tokenizer implements TokenizerInterface
                 $position,
                 $phrase,
                 $negated,
+                $originalPosition,
+                $originalLength,
             );
 
             $position += $token->getLength();
+            $originalPosition += $originalLength;
             $tokens->add($token);
         }
 

--- a/tests/FormatterResultTest.php
+++ b/tests/FormatterResultTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Loupe\Matcher\Tests;
 
 use Loupe\Matcher\FormatterResult;
+use Loupe\Matcher\Matcher;
 use Loupe\Matcher\Tokenizer\Tokenizer;
 use PHPUnit\Framework\TestCase;
 
@@ -45,6 +46,29 @@ final class FormatterResultTest extends TestCase
             [
                 'start' => 8,
                 'length' => 3,
+            ],
+        ], $result->getMatchesArray());
+    }
+
+    public function testNormalizedMatchesArray(): void
+    {
+        $text = 'Die größten Früchte haben die meiste Süße';
+        $query = 'größten Süße';
+
+        $tokenizer = new Tokenizer();
+        $matcher = new Matcher($tokenizer);
+        $matches = $matcher->calculateMatches($text, $query);
+
+        $result = new FormatterResult($text, $matches);
+
+        $this->assertEquals([
+            [
+                'start' => 4,
+                'length' => 7,
+            ],
+            [
+                'start' => 37,
+                'length' => 4,
             ],
         ], $result->getMatchesArray());
     }

--- a/tests/MatcherTest.php
+++ b/tests/MatcherTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Loupe\Matcher\Tests;
 
 use Loupe\Matcher\Matcher;
+use Loupe\Matcher\Tokenizer\LocaleConfiguration\German;
 use Loupe\Matcher\Tokenizer\TokenCollection;
 use Loupe\Matcher\Tokenizer\Tokenizer;
 use PHPUnit\Framework\TestCase;
@@ -34,11 +35,44 @@ final class MatcherTest extends TestCase
         $this->assertSame(15, $spans[0]->getLength());
     }
 
+    public function testDecompositionKeepsCorrectPositions(): void
+    {
+        $text = 'das grosse kuenstlerinnengespraech war fuer die silvesternacht geplant';
+        $query = 'gespraech nacht';
+
+        $tokenizer = new Tokenizer(new German());
+        $matcher = new Matcher($tokenizer);
+        $matches = $matcher->calculateMatches($text, $query);
+        $spans = $matcher->calculateMatchSpans($text, $query, $matches);
+
+        $this->assertEquals(2, \count($matches->all()));
+        $this->assertSame([11, 34], [$spans[0]->getStartPosition(), $spans[0]->getEndPosition()]);
+        $this->assertSame([48, 62], [$spans[1]->getStartPosition(), $spans[1]->getEndPosition()]);
+
+        $words = array_map(fn ($t) => $t->getTerm(), $matches->all());
+        $this->assertEquals(['kuenstlerinnengespraech', 'silvesternacht'], $words);
+    }
+
     public function testEmptyTextReturnsEmptyCollection(): void
     {
         $result = $this->matcher->calculateMatches('', 'query');
         $this->assertInstanceOf(TokenCollection::class, $result);
         $this->assertCount(0, $result->all());
+    }
+
+    public function testNormalizationKeepsCorrectPositions(): void
+    {
+        $text = 'Das große Künstlerinnengespräch war für die Silvesternacht geplant';
+        $query = 'gespräch nacht';
+
+        $tokenizer = new Tokenizer(new German());
+        $matcher = new Matcher($tokenizer);
+        $matches = $matcher->calculateMatches($text, $query);
+        $spans = $matcher->calculateMatchSpans($text, $query, $matches);
+
+        $this->assertEquals(2, \count($matches->all()));
+        $this->assertSame([10, 31], [$spans[0]->getStartPosition(), $spans[0]->getEndPosition()]);
+        $this->assertSame([44, 58], [$spans[1]->getStartPosition(), $spans[1]->getEndPosition()]);
     }
 
     public function testSimpleMatch(): void

--- a/tests/MatcherTest.php
+++ b/tests/MatcherTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Loupe\Matcher\Tests;
 
 use Loupe\Matcher\Matcher;
-use Loupe\Matcher\Tokenizer\LocaleConfiguration\German;
 use Loupe\Matcher\Tokenizer\TokenCollection;
 use Loupe\Matcher\Tokenizer\Tokenizer;
 use PHPUnit\Framework\TestCase;
@@ -35,24 +34,6 @@ final class MatcherTest extends TestCase
         $this->assertSame(15, $spans[0]->getLength());
     }
 
-    public function testDecompositionKeepsCorrectPositions(): void
-    {
-        $text = 'das grosse kuenstlerinnengespraech war fuer die silvesternacht geplant';
-        $query = 'gespraech nacht';
-
-        $tokenizer = new Tokenizer(new German());
-        $matcher = new Matcher($tokenizer);
-        $matches = $matcher->calculateMatches($text, $query);
-        $spans = $matcher->calculateMatchSpans($text, $query, $matches);
-
-        $this->assertEquals(2, \count($matches->all()));
-        $this->assertSame([11, 34], [$spans[0]->getStartPosition(), $spans[0]->getEndPosition()]);
-        $this->assertSame([48, 62], [$spans[1]->getStartPosition(), $spans[1]->getEndPosition()]);
-
-        $words = array_map(fn ($t) => $t->getTerm(), $matches->all());
-        $this->assertEquals(['kuenstlerinnengespraech', 'silvesternacht'], $words);
-    }
-
     public function testEmptyTextReturnsEmptyCollection(): void
     {
         $result = $this->matcher->calculateMatches('', 'query');
@@ -62,17 +43,17 @@ final class MatcherTest extends TestCase
 
     public function testNormalizationKeepsCorrectPositions(): void
     {
-        $text = 'Das große Künstlerinnengespräch war für die Silvesternacht geplant';
-        $query = 'gespräch nacht';
+        $text = 'Das größte Gespräch war für die längste Nacht geplant';
+        $query = 'Gespräch Nacht';
 
-        $tokenizer = new Tokenizer(new German());
+        $tokenizer = new Tokenizer('de');
         $matcher = new Matcher($tokenizer);
         $matches = $matcher->calculateMatches($text, $query);
         $spans = $matcher->calculateMatchSpans($text, $query, $matches);
 
         $this->assertEquals(2, \count($matches->all()));
-        $this->assertSame([10, 31], [$spans[0]->getStartPosition(), $spans[0]->getEndPosition()]);
-        $this->assertSame([44, 58], [$spans[1]->getStartPosition(), $spans[1]->getEndPosition()]);
+        $this->assertSame([11, 19], [$spans[0]->getStartPosition(), $spans[0]->getEndPosition()]);
+        $this->assertSame([40, 45], [$spans[1]->getStartPosition(), $spans[1]->getEndPosition()]);
     }
 
     public function testSimpleMatch(): void

--- a/tests/Tokenizer/TokenizerTest.php
+++ b/tests/Tokenizer/TokenizerTest.php
@@ -12,6 +12,8 @@ class TokenizerTest extends TestCase
     public function testGermanEszettNormalization(): void
     {
         $tokenizer = new Tokenizer();
+        $tokens = $tokenizer->tokenize('Die Straße ist neben dem größeren Gebäude.');
+
         // ß should normalize to ss
         $this->assertSame([
             'die',
@@ -21,8 +23,7 @@ class TokenizerTest extends TestCase
             'dem',
             'grosseren',
             'gebaude',
-        ], $tokenizer->tokenize('Die Straße ist neben dem größeren Gebäude.')
-            ->allTermsWithVariants());
+        ], $tokens->allTermsWithVariants());
     }
 
     public function testIcelandicSpecialCharacters(): void
@@ -166,6 +167,29 @@ class TokenizerTest extends TestCase
             'hase',
             'ich',
         ], $tokens->allNegatedTermsWithVariants());
+    }
+
+    public function testOriginalTermPositionAndLength(): void
+    {
+        $tokenizer = new Tokenizer();
+        $tokens = $tokenizer->tokenize('Die größere Straße ist lang.');
+
+        $this->assertSame([
+            'die',
+            'grossere',
+            'strasse',
+            'ist',
+            'lang',
+        ], $tokens->allTermsWithVariants());
+
+        // The original term length should be remembered even after normalization
+        $this->assertSame(13, $tokens->all()[2]->getStartPosition());
+        $this->assertSame(7, $tokens->all()[2]->getLength());
+        $this->assertSame(20, $tokens->all()[2]->getEndPosition());
+
+        $this->assertSame(12, $tokens->all()[2]->getOriginalStartPosition());
+        $this->assertSame(6, $tokens->all()[2]->getOriginalLength());
+        $this->assertSame(18, $tokens->all()[2]->getOriginalEndPosition());
     }
 
     public function testPolishLNormalization(): void


### PR DESCRIPTION
- Supersedes #16
- Remember the original position and length of tokens
- Reuse them during calculation of match spans
- Fixes incorrect highlighting due to term normalization from the matcher side

**The Loupe side**

- To fix highlighting in Loupe itself, we'll need to store the original position and length in the term-document table
- I'll prepare the PR once this one is approved and merged