### PR TITLE
Fix crop length not being applied correctly

### DIFF
--- a/src/Formatting/Cropper.php
+++ b/src/Formatting/Cropper.php
@@ -82,9 +82,24 @@ class Cropper implements Transformer
             $spans[] = $span;
         }
 
+        if ($spans === []) {
+            return $text;
+        }
+
+        $croppedSpans = [];
+        $remainingLength = $this->cropLength;
+        foreach ($spans as $span) {
+            if ($croppedSpans !== [] && $remainingLength <= 0) {
+                break;
+            }
+
+            $croppedSpans[] = $span;
+            $remainingLength -= $span->getLength();
+        }
+
         // Put back together and add crop markers
         $result = '';
-        foreach ($spans as $span) {
+        foreach ($croppedSpans as $span) {
             if ($span->getStartPosition() > 0) {
                 $result .= $this->cropMarker;
             }

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -51,7 +51,7 @@ class FormatterTest extends TestCase
         yield 'Cropping with less context and change' => [
             'taken',
             'A wonderful serenity has taken possession of my entire soul, like these sweet mornings have taken all spring.',
-            '…serenity has taken possession…mornings have taken all spring…',
+            '…serenity has taken possession…',
             true,
             25,
         ];
@@ -66,14 +66,14 @@ class FormatterTest extends TestCase
         yield 'Cropping around repeating term' => [
             'soul',
             'A wonderful serenity has taken possession of my entire soul, like these sweet mornings of spring which I enjoy with my whole soul. I am alone, and feel the charm of existence in this spot, which was created for the bliss of a soul like mine.',
-            '…serenity has taken possession of my entire soul, like these sweet mornings of spring which I enjoy with my whole soul. I am alone, and feel the charm of existence…which was created for the bliss of a soul like mine.',
+            '…serenity has taken possession of my entire soul, like these sweet mornings of spring which I enjoy with my whole soul. I am alone, and feel the charm of existence…',
             true,
         ];
 
         yield 'Cropping around multiple terms' => [
             'soul bliss',
             'A wonderful serenity has taken possession of my entire soul, like these sweet mornings of spring which I enjoy with my whole being. I am alone, and feel the charm of existence in this spot, which was created for the bliss of a heart like mine.',
-            '…serenity has taken possession of my entire soul, like these sweet mornings of spring…this spot, which was created for the bliss of a heart like mine.',
+            '…serenity has taken possession of my entire soul, like these sweet mornings of spring…',
             true,
         ];
 
@@ -94,7 +94,7 @@ class FormatterTest extends TestCase
         yield 'Cropping with custom length' => [
             'whole entire',
             'Wonderful serenity has taken possession of my entire soul, like these sweet mornings of spring which I enjoy with my whole panorama.',
-            '…my entire soul…with my whole pano…',
+            '…my entire soul…',
             true,
             15,
         ];
@@ -102,10 +102,18 @@ class FormatterTest extends TestCase
         yield 'Cropping with custom marker' => [
             'whole entire',
             'Wonderful serenity has taken possession of my entire soul, like these sweet mornings of spring which I enjoy with my whole panorama.',
-            ' --- possession of my entire soul, like --- enjoy with my whole panorama.',
+            ' --- possession of my entire soul, like --- ',
             true,
             25,
             ' --- ',
+        ];
+
+        yield 'Cropping with many distant matches stays bounded' => [
+            'needle',
+            trim(str_repeat('prefix filler filler filler filler filler needle suffix filler filler filler filler filler ', 20)),
+            '…filler filler needle suffix filler…',
+            true,
+            25,
         ];
     }
 
@@ -281,7 +289,7 @@ class FormatterTest extends TestCase
         $formatter = new Formatter($this->matcher);
         $result = $formatter->format('This is a test string and we use it to test the cropping and highlighting features combined.', $this->queryTerms, $options);
 
-        $this->assertSame('…his is a [test] string and…use it to [test] the cropping…', $result->getFormattedText());
+        $this->assertSame('…his is a [test] string and…', $result->getFormattedText());
 
     }
 

--- a/tests/Formatting/CropperTest.php
+++ b/tests/Formatting/CropperTest.php
@@ -19,7 +19,7 @@ class CropperTest extends TestCase
 
         yield 'Cropping with less context and change' => [
             'A wonderful serenity has <em>taken</em> possession of my entire soul, like these sweet mornings have <em>taken</em> all spring.',
-            '…serenity has <em>taken</em> possession…mornings have <em>taken</em> all spring…',
+            '…serenity has <em>taken</em> possession…',
             25,
         ];
 
@@ -30,12 +30,12 @@ class CropperTest extends TestCase
 
         yield 'Cropping around repeating term' => [
             'A wonderful serenity has taken possession of my entire <em>soul</em>, like these sweet mornings of spring which I enjoy with my whole <em>soul</em>. I am alone, and feel the charm of existence in this spot, which was created for the bliss of a <em>soul</em> like mine.',
-            '…serenity has taken possession of my entire <em>soul</em>, like these sweet mornings of spring which I enjoy with my whole <em>soul</em>. I am alone, and feel the charm of existence…which was created for the bliss of a <em>soul</em> like mine.',
+            '…serenity has taken possession of my entire <em>soul</em>, like these sweet mornings of spring which I enjoy with my whole <em>soul</em>. I am alone, and feel the charm of existence…',
         ];
 
         yield 'Cropping around multiple terms' => [
             'A wonderful serenity has taken possession of my entire <em>soul</em>, like these sweet mornings of spring which I enjoy with my whole being. I am alone, and feel the charm of existence in this spot, which was created for the <em>bliss</em> of a heart like mine.',
-            '…serenity has taken possession of my entire <em>soul</em>, like these sweet mornings of spring…this spot, which was created for the <em>bliss</em> of a heart like mine.',
+            '…serenity has taken possession of my entire <em>soul</em>, like these sweet mornings of spring…',
         ];
 
         yield 'Cropping at start' => [
@@ -50,24 +50,30 @@ class CropperTest extends TestCase
 
         yield 'Cropping with custom length' => [
             'Wonderful serenity has taken possession of my <em>entire</em> soul, like these sweet mornings of spring which I enjoy with my <em>whole</em> panorama.',
-            '…my <em>entire</em> soul…with my <em>whole</em> pano…',
+            '…my <em>entire</em> soul…',
             15,
         ];
 
         yield 'Cropping with custom marker' => [
             'Wonderful serenity has taken possession of my <em>entire</em> soul, like these sweet mornings of spring which I enjoy with my <em>whole</em> panorama.',
-            ' --- possession of my <em>entire</em> soul, like --- enjoy with my <em>whole</em> panorama.',
+            ' --- possession of my <em>entire</em> soul, like --- ',
             25,
             ' --- ',
         ];
 
         yield 'Cropping with custom highlight tags' => [
             'Wonderful serenity has taken <mark>possession</mark> of my <em>entire</em> soul, like these sweet mornings of <mark>spring</mark> which I enjoy with my <em>whole</em> panorama.',
-            '…taken <mark>possession</mark> of my <em>entire</em>…mornings of <mark>spring</mark> which I enjoy…',
+            '…taken <mark>possession</mark> of my <em>entire</em>…',
             25,
             '…',
             '<mark>',
             '</mark>',
+        ];
+
+        yield 'Cropping with many distant highlights stays bounded' => [
+            str_repeat('prefix filler filler filler filler filler <em>needle</em> suffix filler filler filler filler filler ', 20),
+            '…filler filler <em>needle</em> suffix filler…',
+            25,
         ];
     }
 


### PR DESCRIPTION
This PR fixes snippet cropping so `cropLength` is actually enforced when multiple highlighted matches are far apart.

Previously, the cropper could include multiple non-overlapping spans and return output that was much longer than the configured crop length. With this change, cropping stops once the configured length budget has been consumed, while still preserving highlight tags and crop markers.

I'm not quite sure the implementation and test updates are correct so requesting @daun's review as per usual 🤣 