### PR TITLE
Truncation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The `Formatter` orchestrates the entire process:
 
 - Highlights matched terms with HTML tags
 - Crops text to show relevant context around matches
+- Truncates long text while preserving word boundaries and highlights
 - Configurable through `FormatterOptions`
 
 ```php
@@ -104,7 +105,10 @@ $options = (new FormatterOptions())
     ->withHighlightEndTag('</mark>')
     ->withEnableCrop()
     ->withCropLength(150)
-    ->withCropMarker('...');
+    ->withCropMarker(' ... ')
+    ->withEnableTruncation()
+    ->withTruncationLength(200)
+    ->withTruncationMarker('...');
 
 $result = $formatter->format($text, $query, $options);
 echo $result->getFormattedText();

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -6,6 +6,7 @@ namespace Loupe\Matcher;
 
 use Loupe\Matcher\Formatting\Cropper;
 use Loupe\Matcher\Formatting\Highlighter;
+use Loupe\Matcher\Formatting\Truncator;
 use Loupe\Matcher\Formatting\Unhighlighter;
 use Loupe\Matcher\Tokenizer\TokenCollection;
 
@@ -26,6 +27,9 @@ class Formatter
         }
         if ($options->shouldCrop()) {
             $transformers[] = new Cropper($options->getCropLength(), $options->getCropMarker(), $options->getHighlightStartTag(), $options->getHighlightEndTag());
+        }
+        if ($options->shouldTruncate()) {
+            $transformers[] = new Truncator($options->getTruncationLength(), $options->getTruncationMarker(), $options->getHighlightStartTag(), $options->getHighlightEndTag());
         }
         if (!$options->shouldHighlight()) {
             $transformers[] = new Unhighlighter($options->getHighlightStartTag(), $options->getHighlightEndTag());

--- a/src/FormatterOptions.php
+++ b/src/FormatterOptions.php
@@ -18,12 +18,21 @@ class FormatterOptions
 
     private bool $shouldHighlight = false;
 
+    private bool $shouldTruncate = false;
+
+    private int $truncationLength = 250;
+
+    private string $truncationMarker = '…';
+
     /**
      * @param array{
      *     crop_length?: int,
      *     crop_marker?: string,
      *     enable_crop?: bool,
      *     enable_highlight?: bool,
+     *     enable_truncation?: bool,
+     *     truncation_length?: int,
+     *     truncation_marker?: string,
      *     highlight_start_tag?: string,
      *     highlight_end_tag?: string
      * } $options
@@ -60,6 +69,20 @@ class FormatterOptions
             $formatterOptions = $formatterOptions->withHighlightEndTag($options['highlight_end_tag']);
         }
 
+        if (\array_key_exists('enable_truncation', $options)) {
+            $formatterOptions = $options['enable_truncation']
+                ? $formatterOptions->withEnableTruncation()
+                : $formatterOptions->withDisableTruncation();
+        }
+
+        if (isset($options['truncation_length'])) {
+            $formatterOptions = $formatterOptions->withTruncationLength((int) $options['truncation_length']);
+        }
+
+        if (isset($options['truncation_marker'])) {
+            $formatterOptions = $formatterOptions->withTruncationMarker($options['truncation_marker']);
+        }
+
         return $formatterOptions;
     }
 
@@ -83,6 +106,16 @@ class FormatterOptions
         return $this->highlightStartTag;
     }
 
+    public function getTruncationLength(): int
+    {
+        return $this->truncationLength;
+    }
+
+    public function getTruncationMarker(): string
+    {
+        return $this->truncationMarker;
+    }
+
     public function shouldCrop(): bool
     {
         return $this->shouldCrop;
@@ -91,6 +124,11 @@ class FormatterOptions
     public function shouldHighlight(): bool
     {
         return $this->shouldHighlight;
+    }
+
+    public function shouldTruncate(): bool
+    {
+        return $this->shouldTruncate;
     }
 
     public function withCropLength(int $cropLength): self
@@ -123,6 +161,14 @@ class FormatterOptions
         return $clone;
     }
 
+    public function withDisableTruncation(): self
+    {
+        $clone = clone $this;
+        $clone->shouldTruncate = false;
+
+        return $clone;
+    }
+
     public function withEnableCrop(): self
     {
         $clone = clone $this;
@@ -138,6 +184,14 @@ class FormatterOptions
         return $clone;
     }
 
+    public function withEnableTruncation(): self
+    {
+        $clone = clone $this;
+        $clone->shouldTruncate = true;
+
+        return $clone;
+    }
+
     public function withHighlightEndTag(string $endTag): self
     {
         $clone = clone $this;
@@ -149,6 +203,20 @@ class FormatterOptions
     {
         $clone = clone $this;
         $clone->highlightStartTag = $startTag;
+        return $clone;
+    }
+
+    public function withTruncationLength(int $truncationLength): self
+    {
+        $clone = clone $this;
+        $clone->truncationLength = $truncationLength;
+        return $clone;
+    }
+
+    public function withTruncationMarker(string $truncationMarker): self
+    {
+        $clone = clone $this;
+        $clone->truncationMarker = $truncationMarker;
         return $clone;
     }
 }

--- a/src/Formatting/Truncator.php
+++ b/src/Formatting/Truncator.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Matcher\Formatting;
+
+use Loupe\Matcher\Tokenizer\TokenCollection;
+
+class Truncator implements Transformer
+{
+    public function __construct(
+        private int $truncationLength,
+        private string $truncationMarker,
+        private string $highlightStartTag,
+        private string $highlightEndTag,
+    ) {
+    }
+
+    public function transform(string $text, TokenCollection|string $query, TokenCollection $matches): string
+    {
+        if ($this->truncationLength <= 0 || $text === '') {
+            return $text;
+        }
+
+        $hasTags = $this->highlightStartTag !== '' && $this->highlightEndTag !== '';
+
+        if ($hasTags) {
+            $pattern = '/(' . preg_quote($this->highlightStartTag, '/') . '|' . preg_quote($this->highlightEndTag, '/') . ')/u';
+            $segments = preg_split($pattern, $text, -1, PREG_SPLIT_DELIM_CAPTURE);
+        } else {
+            $segments = [$text];
+        }
+
+        if ($segments === false) {
+            return $text;
+        }
+
+        $result = '';
+        $truncatedLength = 0;
+        $wasTruncated = false;
+        $insideHighlight = false;
+
+        foreach ($segments as $segment) {
+            if ($segment === '') {
+                continue;
+            }
+
+            if ($hasTags && $segment === $this->highlightStartTag) {
+                $result .= $segment;
+                $insideHighlight = true;
+                continue;
+            }
+
+            if ($hasTags && $segment === $this->highlightEndTag) {
+                $result .= $segment;
+                $insideHighlight = false;
+                continue;
+            }
+
+            $segmentLength = mb_strlen($segment, 'UTF-8');
+
+            if ($truncatedLength + $segmentLength <= $this->truncationLength) {
+                $result .= $segment;
+                $truncatedLength += $segmentLength;
+                continue;
+            }
+
+            $remainingLength = $this->truncationLength - $truncatedLength;
+            $wasTruncatedAt = $this->snapBackToBoundary($segment, $remainingLength);
+            $result .= mb_substr($segment, 0, $wasTruncatedAt, 'UTF-8');
+
+            if ($insideHighlight) {
+                $result .= $this->highlightEndTag;
+            }
+
+            $wasTruncated = true;
+            break;
+        }
+
+        if ($wasTruncated) {
+            $result .= $this->truncationMarker;
+        }
+
+        return $result;
+    }
+
+    private function snapBackToBoundary(string $segment, int $maxLength): int
+    {
+        if ($maxLength <= 0) {
+            return 0;
+        }
+
+        $segmentLength = mb_strlen($segment, 'UTF-8');
+        if ($maxLength >= $segmentLength) {
+            return $segmentLength;
+        }
+
+        $boundaries = [' ', "\t", "\n", "\r"];
+        for ($i = $maxLength; $i > 0; $i--) {
+            $char = mb_substr($segment, $i - 1, 1, 'UTF-8');
+            if (\in_array($char, $boundaries, true)) {
+                return $i - 1;
+            }
+        }
+
+        return $maxLength;
+    }
+}

--- a/src/Formatting/Truncator.php
+++ b/src/Formatting/Truncator.php
@@ -8,6 +8,8 @@ use Loupe\Matcher\Tokenizer\TokenCollection;
 
 class Truncator implements Transformer
 {
+    private const WORD_BOUNDARIES = [' ', "\t", "\n", "\r"];
+
     public function __construct(
         private int $truncationLength,
         private string $truncationMarker,
@@ -36,9 +38,13 @@ class Truncator implements Transformer
         }
 
         $result = '';
-        $truncatedLength = 0;
-        $wasTruncated = false;
+        $visibleLength = 0;
         $insideHighlight = false;
+        $lastVisibleChar = null;
+
+        $checkpointResult = '';
+        $checkpointInsideHighlight = false;
+        $wasTruncated = false;
 
         foreach ($segments as $segment) {
             if ($segment === '') {
@@ -57,52 +63,38 @@ class Truncator implements Transformer
                 continue;
             }
 
-            $segmentLength = mb_strlen($segment, 'UTF-8');
+            $remainingBudget = $this->truncationLength - $visibleLength + 1;
+            $relevantSegment = mb_substr($segment, 0, $remainingBudget, 'UTF-8');
 
-            if ($truncatedLength + $segmentLength <= $this->truncationLength) {
-                $result .= $segment;
-                $truncatedLength += $segmentLength;
-                continue;
+            foreach (mb_str_split($relevantSegment, 1, 'UTF-8') as $char) {
+                $isBoundary = \in_array($char, self::WORD_BOUNDARIES, true);
+
+                if ($isBoundary && $lastVisibleChar !== null && !\in_array($lastVisibleChar, self::WORD_BOUNDARIES, true)) {
+                    $checkpointResult = $result;
+                    $checkpointInsideHighlight = $insideHighlight;
+                }
+
+                if ($visibleLength >= $this->truncationLength) {
+                    $wasTruncated = true;
+                    break 2;
+                }
+
+                $result .= $char;
+                $visibleLength++;
+                $lastVisibleChar = $char;
             }
-
-            $remainingLength = $this->truncationLength - $truncatedLength;
-            $wasTruncatedAt = $this->snapBackToBoundary($segment, $remainingLength);
-            $result .= mb_substr($segment, 0, $wasTruncatedAt, 'UTF-8');
-
-            if ($insideHighlight) {
-                $result .= $this->highlightEndTag;
-            }
-
-            $wasTruncated = true;
-            break;
         }
 
-        if ($wasTruncated) {
-            $result .= $this->truncationMarker;
+        if (!$wasTruncated) {
+            return $result;
         }
+
+        $result = $checkpointResult;
+        if ($checkpointInsideHighlight) {
+            $result .= $this->highlightEndTag;
+        }
+        $result .= $this->truncationMarker;
 
         return $result;
-    }
-
-    private function snapBackToBoundary(string $segment, int $maxLength): int
-    {
-        if ($maxLength <= 0) {
-            return 0;
-        }
-
-        $segmentLength = mb_strlen($segment, 'UTF-8');
-        if ($maxLength >= $segmentLength) {
-            return $segmentLength;
-        }
-
-        $boundaries = [' ', "\t", "\n", "\r"];
-        for ($i = $maxLength; $i > 0; $i--) {
-            $char = mb_substr($segment, $i - 1, 1, 'UTF-8');
-            if (\in_array($char, $boundaries, true)) {
-                return $i - 1;
-            }
-        }
-
-        return $maxLength;
     }
 }

--- a/tests/FormatterOptionsTest.php
+++ b/tests/FormatterOptionsTest.php
@@ -15,8 +15,11 @@ final class FormatterOptionsTest extends TestCase
 
         $this->assertFalse($options->shouldCrop());
         $this->assertFalse($options->shouldHighlight());
+        $this->assertFalse($options->shouldTruncate());
         $this->assertEquals(50, $options->getCropLength());
         $this->assertEquals('…', $options->getCropMarker());
+        $this->assertEquals(250, $options->getTruncationLength());
+        $this->assertEquals('…', $options->getTruncationMarker());
         $this->assertEquals('<em>', $options->getHighlightStartTag());
         $this->assertEquals('</em>', $options->getHighlightEndTag());
     }
@@ -30,24 +33,33 @@ final class FormatterOptionsTest extends TestCase
             'enable_highlight' => true,
             'highlight_start_tag' => '<strong>',
             'highlight_end_tag' => '</strong>',
+            'enable_truncation' => true,
+            'truncation_length' => 100,
+            'truncation_marker' => ' ...',
         ]);
 
-        $this->assertEquals(20, $options->getCropLength());
-        $this->assertEquals('...', $options->getCropMarker());
         $this->assertTrue($options->shouldCrop());
         $this->assertTrue($options->shouldHighlight());
+        $this->assertTrue($options->shouldTruncate());
+        $this->assertEquals(20, $options->getCropLength());
+        $this->assertEquals('...', $options->getCropMarker());
         $this->assertEquals('<strong>', $options->getHighlightStartTag());
         $this->assertEquals('</strong>', $options->getHighlightEndTag());
+        $this->assertEquals(100, $options->getTruncationLength());
+        $this->assertEquals(' ...', $options->getTruncationMarker());
     }
 
     public function testFromArrayWithDefaults(): void
     {
         $options = FormatterOptions::fromArray([]);
 
-        $this->assertEquals(50, $options->getCropLength());
-        $this->assertEquals('…', $options->getCropMarker());
         $this->assertFalse($options->shouldCrop());
         $this->assertFalse($options->shouldHighlight());
+        $this->assertFalse($options->shouldTruncate());
+        $this->assertEquals(50, $options->getCropLength());
+        $this->assertEquals('…', $options->getCropMarker());
+        $this->assertEquals(250, $options->getTruncationLength());
+        $this->assertEquals('…', $options->getTruncationMarker());
         $this->assertEquals('<em>', $options->getHighlightStartTag());
         $this->assertEquals('</em>', $options->getHighlightEndTag());
     }
@@ -57,10 +69,12 @@ final class FormatterOptionsTest extends TestCase
         $options = FormatterOptions::fromArray([
             'enable_crop' => false,
             'enable_highlight' => false,
+            'enable_truncation' => false,
         ]);
 
         $this->assertFalse($options->shouldCrop());
         $this->assertFalse($options->shouldHighlight());
+        $this->assertFalse($options->shouldTruncate());
     }
 
     public function testWithCropLength(): void
@@ -99,6 +113,15 @@ final class FormatterOptionsTest extends TestCase
         $this->assertFalse($newOptions->shouldHighlight());
     }
 
+    public function testWithDisableTruncation(): void
+    {
+        $options = (new FormatterOptions())->withEnableTruncation();
+        $newOptions = $options->withDisableTruncation();
+
+        $this->assertTrue($options->shouldTruncate());
+        $this->assertFalse($newOptions->shouldTruncate());
+    }
+
     public function testWithEnableCrop(): void
     {
         $options = new FormatterOptions();
@@ -117,6 +140,15 @@ final class FormatterOptionsTest extends TestCase
         $this->assertTrue($newOptions->shouldHighlight());
     }
 
+    public function testWithEnableTruncation(): void
+    {
+        $options = new FormatterOptions();
+        $newOptions = $options->withEnableTruncation();
+
+        $this->assertFalse($options->shouldTruncate());
+        $this->assertTrue($newOptions->shouldTruncate());
+    }
+
     public function testWithHighlightEndTag(): void
     {
         $options = new FormatterOptions();
@@ -133,5 +165,14 @@ final class FormatterOptionsTest extends TestCase
 
         $this->assertEquals('<em>', $options->getHighlightStartTag());
         $this->assertEquals('<strong>', $newOptions->getHighlightStartTag());
+    }
+
+    public function testWithTruncationLength(): void
+    {
+        $options = new FormatterOptions();
+        $newOptions = $options->withTruncationLength(100);
+
+        $this->assertEquals(250, $options->getTruncationLength());
+        $this->assertEquals(100, $newOptions->getTruncationLength());
     }
 }

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -240,6 +240,22 @@ class FormatterTest extends TestCase
         $this->assertSame($expectedResult, $result->getFormattedText());
     }
 
+    public function testFormatTruncationClosesOpenHighlight(): void
+    {
+        $options = (new FormatterOptions())
+            ->withEnableHighlight()
+            ->withEnableTruncation()
+            ->withHighlightStartTag('[')
+            ->withHighlightEndTag(']')
+            ->withTruncationLength(12)
+        ;
+
+        $formatter = new Formatter($this->matcher);
+        $result = $formatter->format('this is a test of patience to find a suitable example', $this->queryTerms, $options);
+
+        $this->assertSame('this is a [te]…', $result->getFormattedText());
+    }
+
     public function testFormatWithCrop(): void
     {
         $options = (new FormatterOptions())
@@ -252,6 +268,21 @@ class FormatterTest extends TestCase
         $result = $formatter->format('This is a test string used for cropping.', $this->queryTerms, $options);
 
         $this->assertSame('...a test string...', $result->getFormattedText());
+    }
+
+    public function testFormatWithCropAndTruncation(): void
+    {
+        $options = (new FormatterOptions())
+            ->withEnableCrop()
+            ->withEnableTruncation()
+            ->withCropLength(15)
+            ->withTruncationLength(25)
+        ;
+
+        $formatter = new Formatter($this->matcher);
+        $result = $formatter->format('This is a test string and we use it to test the cropping and highlighting features combined.', $this->queryTerms, $options);
+
+        $this->assertSame('…is a test string…it to t…', $result->getFormattedText());
     }
 
     public function testFormatWithHighlight(): void
@@ -285,6 +316,22 @@ class FormatterTest extends TestCase
 
     }
 
+    public function testFormatWithHighlightAndTruncation(): void
+    {
+        $options = (new FormatterOptions())
+            ->withEnableHighlight()
+            ->withEnableTruncation()
+            ->withHighlightStartTag('[')
+            ->withHighlightEndTag(']')
+            ->withTruncationLength(20)
+        ;
+
+        $formatter = new Formatter($this->matcher);
+        $result = $formatter->format('This is a test string used for truncation testing.', $this->queryTerms, $options);
+
+        $this->assertSame('This is a [test]…', $result->getFormattedText());
+    }
+
     public function testFormatWithoutHighlightOrCrop(): void
     {
         $options = new FormatterOptions();
@@ -293,6 +340,20 @@ class FormatterTest extends TestCase
         $result = $formatter->format('This is a test string.', $this->queryTerms, $options);
 
         $this->assertSame('This is a test string.', $result->getFormattedText());
+    }
+
+    public function testFormatWithTruncation(): void
+    {
+        $options = (new FormatterOptions())
+            ->withEnableTruncation()
+            ->withTruncationLength(20)
+            ->withTruncationMarker('...')
+        ;
+
+        $formatter = new Formatter($this->matcher);
+        $result = $formatter->format('This is a test string used for truncation testing.', $this->queryTerms, $options);
+
+        $this->assertSame('This is a test...', $result->getFormattedText());
     }
 
     #[DataProvider('highlightingProvider')]
@@ -319,5 +380,81 @@ class FormatterTest extends TestCase
         $result = $formatter->format($text, $query, $options);
 
         $this->assertSame($expectedResult, $result->getFormattedText());
+    }
+
+    #[DataProvider('truncationProvider')]
+    public function testTruncation(
+        string|TokenCollection $query,
+        string $text,
+        string $expectedResult,
+        bool $enableTruncation = false,
+        int $truncationLength = 250,
+        string $truncationMarker = '…',
+    ): void {
+        $options = (new FormatterOptions());
+        if ($enableTruncation) {
+            $options = $options->withEnableTruncation()
+                ->withTruncationLength($truncationLength)
+                ->withTruncationMarker($truncationMarker);
+        } else {
+            $options = $options->withDisableTruncation();
+        }
+
+        $query = $query instanceof TokenCollection ? $query : (new Tokenizer())->tokenize($query);
+
+        $formatter = new Formatter($this->matcher);
+        $result = $formatter->format($text, $query, $options);
+
+        $this->assertSame($expectedResult, $result->getFormattedText());
+    }
+
+    public static function truncationProvider(): \Generator
+    {
+        yield 'No truncation' => [
+            'soul',
+            'A wonderful serenity has taken possession of my entire soul.',
+            'A wonderful serenity has taken possession of my entire soul.',
+        ];
+
+        yield 'Text shorter than limit is unchanged' => [
+            'soul',
+            'A wonderful serenity has taken possession of my entire soul.',
+            'A wonderful serenity has taken possession of my entire soul.',
+            true,
+            250,
+        ];
+
+        yield 'Truncates at word boundary with marker' => [
+            'soul',
+            'A wonderful serenity has taken possession of my entire soul, like these sweet mornings of spring which I enjoy with my whole soul.',
+            'A wonderful serenity has taken possession of my entire soul, like these sweet…',
+            true,
+            80,
+        ];
+
+        yield 'Truncates with custom marker' => [
+            'soul',
+            'A wonderful serenity has taken possession of my entire soul.',
+            'A wonderful serenity has taken [...]',
+            true,
+            32,
+            ' [...]',
+        ];
+
+        yield 'Truncation length zero is a no-op' => [
+            'soul',
+            'A wonderful serenity has taken possession of my entire soul.',
+            'A wonderful serenity has taken possession of my entire soul.',
+            true,
+            0,
+        ];
+
+        yield 'Truncates multibyte text safely' => [
+            'café',
+            'A café in Zürich is où you naïvely meet for piña coladas and crème brûlée.',
+            'A café in Zürich is où you naïvely meet for piña…',
+            true,
+            50,
+        ];
     }
 }

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -242,6 +242,25 @@ class FormatterTest extends TestCase
 
     public function testFormatTruncationClosesOpenHighlight(): void
     {
+        $tokenizer = new Tokenizer();
+        $query = $tokenizer->tokenize('a meeting of souls');
+
+        $options = (new FormatterOptions())
+            ->withEnableHighlight()
+            ->withEnableTruncation()
+            ->withHighlightStartTag('[')
+            ->withHighlightEndTag(']')
+            ->withTruncationLength(10)
+        ;
+
+        $formatter = new Formatter($this->matcher);
+        $result = $formatter->format('A meeting of souls has taken possession.', $query, $options);
+
+        $this->assertSame('[A meeting]…', $result->getFormattedText());
+    }
+
+    public function testFormatTruncationDoesNotCutWords(): void
+    {
         $options = (new FormatterOptions())
             ->withEnableHighlight()
             ->withEnableTruncation()
@@ -253,7 +272,7 @@ class FormatterTest extends TestCase
         $formatter = new Formatter($this->matcher);
         $result = $formatter->format('this is a test of patience to find a suitable example', $this->queryTerms, $options);
 
-        $this->assertSame('this is a [te]…', $result->getFormattedText());
+        $this->assertSame('this is a…', $result->getFormattedText());
     }
 
     public function testFormatWithCrop(): void
@@ -276,13 +295,13 @@ class FormatterTest extends TestCase
             ->withEnableCrop()
             ->withEnableTruncation()
             ->withCropLength(15)
-            ->withTruncationLength(25)
+            ->withTruncationLength(35)
         ;
 
         $formatter = new Formatter($this->matcher);
         $result = $formatter->format('This is a test string and we use it to test the cropping and highlighting features combined.', $this->queryTerms, $options);
 
-        $this->assertSame('…is a test string…it to t…', $result->getFormattedText());
+        $this->assertSame('…is a test string…it to test the…', $result->getFormattedText());
     }
 
     public function testFormatWithHighlight(): void


### PR DESCRIPTION
Add a new formatting feature: truncation.

Implemented as naive head-truncation: begin at `0`, fill with words until budget is filled.
Applied after cropping, i.e. crop windows are assembled first, then truncated as a whole.

I'm working on a smart truncation/cropping feature that chooses the best window(s) for density of matches, but that's another PR coming up. Should ultimately make things more performant when combining cropping + truncation, though.

```php
$options = (new FormatterOptions())
    ->withEnableTruncation()
    ->withTruncationLength(200)
    ->withTruncationMarker('...');
```