### PR TITLE
Use smaller corpus for control benchmark

### DIFF
--- a/tests/Benchmark/TokenizerBench.php
+++ b/tests/Benchmark/TokenizerBench.php
@@ -35,9 +35,8 @@ class TokenizerBench
     }
 
     /**
-     * Pure ICU break-iterator pass — no Tokenizer code involved.
-     * Drift here between baseline and PR indicates environmental noise
-     * (runner load, thermal state), not a real regression in Tokenizer.
+     * Pure ICU break-iterator pass over 1000 terms without Tokenizer involved.
+     * Used to distinguish environmental noise (runner load, thermal state) from real regressions in Tokenizer.
      */
     #[ParamProviders('provideCorpus')]
     #[Groups(['control'])]
@@ -49,13 +48,23 @@ class TokenizerBench
         }
     }
 
-    #[ParamProviders('provideCorpus')]
+    #[ParamProviders('provideVariableLengthCorpuses')]
     public function benchTokenize(): void
     {
         $this->tokenizer->tokenize($this->text);
     }
 
     public function provideCorpus(): \Generator
+    {
+        foreach (['en', 'de'] as $locale) {
+            yield "{$locale}-1000" => [
+                'locale' => $locale,
+                'size' => 1000,
+            ];
+        }
+    }
+
+    public function provideVariableLengthCorpuses(): \Generator
     {
         foreach (['en', 'de'] as $locale) {
             foreach ([100, 1000, 10000] as $size) {


### PR DESCRIPTION
- The control benchmark for tokenization runs with the full 100 + 1k + 10k corpus
- Should be enough to run it with the simple 1k corpus
- Renamed the providers for clarity: `provideCorpus` = 1k, `provideVariableLengthCorpuses` = 100 + 1k + 10k