### PR TITLE
Fix grouping of adjacent quoted phrases

### DIFF
--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -12,6 +12,8 @@ class Token
 
     private int $originalStartPosition;
 
+    private bool $startsPhrase = false;
+
     /**
      * @var array<string>
      */
@@ -156,6 +158,20 @@ class Token
 
         $clone = clone $this;
         $clone->variants = array_unique(array_merge($this->variants, $variants));
+
+        return $clone;
+    }
+
+    public function startsPhrase(): bool
+    {
+        return $this->startsPhrase;
+    }
+
+    public function withPhraseStart(): self
+    {
+        $clone = clone $this;
+        $clone->isPartOfPhrase = true;
+        $clone->startsPhrase = true;
 
         return $clone;
     }

--- a/src/Tokenizer/TokenCollection.php
+++ b/src/Tokenizer/TokenCollection.php
@@ -155,6 +155,11 @@ class TokenCollection implements \Countable
 
         foreach ($this->tokens as $token) {
             if ($token->isPartOfPhrase()) {
+                if (null !== $phrase && $token->startsPhrase()) {
+                    $groups[] = $phrase;
+                    $phrase = null;
+                }
+
                 $phrase ??= new Phrase([], $token->isNegated());
                 $phrase->add($token);
             } else {

--- a/src/Tokenizer/Tokenizer.php
+++ b/src/Tokenizer/Tokenizer.php
@@ -62,6 +62,7 @@ class Tokenizer implements TokenizerInterface
         $position = 0;
         $originalPosition = 0;
         $phrase = false;
+        $startsPhrase = false;
         $negated = false;
         $whitespace = true;
 
@@ -79,7 +80,10 @@ class Tokenizer implements TokenizerInterface
             // Toggle phrases between quotes
             if ('"' === $term) {
                 $phrase = !$phrase;
-                if (!$phrase) {
+                if ($phrase) {
+                    $startsPhrase = true;
+                } else {
+                    $startsPhrase = false;
                     $negated = false;
                 }
             }
@@ -129,6 +133,11 @@ class Tokenizer implements TokenizerInterface
                 $originalLength,
                 $termLength,
             );
+
+            if ($startsPhrase) {
+                $token = $token->withPhraseStart();
+                $startsPhrase = false;
+            }
 
             if ($enhanceTokens) {
                 $token = $localeConfiguration->enhanceToken($token);

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -213,6 +213,15 @@ final class FormatterTest extends TestCase
             '[',
             ']',
         ];
+
+        yield 'Highlighting with adjacent quoted phrases' => [
+            '"quick brown" "lazy dog"',
+            'The quick brown fox jumps over the lazy dog',
+            'The [quick brown] fox jumps over the [lazy dog]',
+            true,
+            '[',
+            ']',
+        ];
     }
 
     /**

--- a/tests/Tokenizer/TokenCollectionTest.php
+++ b/tests/Tokenizer/TokenCollectionTest.php
@@ -5,11 +5,70 @@ declare(strict_types=1);
 namespace Loupe\Matcher\Tests\Tokenizer;
 
 use Loupe\Matcher\StopWords\InMemoryStopWords;
+use Loupe\Matcher\Tokenizer\Phrase;
+use Loupe\Matcher\Tokenizer\Token;
+use Loupe\Matcher\Tokenizer\TokenCollection;
 use Loupe\Matcher\Tokenizer\Tokenizer;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 final class TokenCollectionTest extends TestCase
 {
+    /**
+     * @param array<array<string>> $expectedTerms
+     * @param array<bool>          $expectedNegated
+     */
+    #[TestWith(['"one two"', [['one', 'two']], [false]], 'one phrase')]
+    #[TestWith(['"one two" "three four"', [['one', 'two'], ['three', 'four']], [false, false]], 'adjacent phrases')]
+    #[TestWith(['"one two" unquoted "three four"', [['one', 'two'], ['unquoted'], ['three', 'four']], [false, false, false]], 'phrases separated by a token')]
+    #[TestWith(['"one two"   "three four"', [['one', 'two'], ['three', 'four']], [false, false]], 'phrases separated by multiple spaces')]
+    #[TestWith(['"one two", "three four"', [['one', 'two'], ['three', 'four']], [false, false]], 'phrases separated by punctuation')]
+    #[TestWith(['-"one two" -"three four"', [['one', 'two'], ['three', 'four']], [true, true]], 'negated phrases')]
+    #[TestWith(['unquoted "one two', [['unquoted'], ['one', 'two']], [false, false]], 'unclosed phrase')]
+    public function testPhraseGroups(string $query, array $expectedTerms, array $expectedNegated): void
+    {
+        $groups = (new Tokenizer())->tokenize($query)->phraseGroups();
+
+        $actualTerms = [];
+        $actualNegated = [];
+
+        foreach ($groups as $group) {
+            $actualTerms[] = array_map(
+                static fn (Token $token): string => $token->getTerm(),
+                $group->all(),
+            );
+            $actualNegated[] = $group->isNegated();
+        }
+
+        $this->assertSame($expectedTerms, $actualTerms);
+        $this->assertSame($expectedNegated, $actualNegated);
+        $this->assertInstanceOf(Phrase::class, $groups[array_key_last($groups)]);
+    }
+
+    public function testPhraseStartDistinguishesAdjacentPhrases(): void
+    {
+        $tokens = (new Tokenizer())->tokenize('"one two" "three four"')->all();
+
+        $this->assertTrue($tokens[0]->startsPhrase());
+        $this->assertFalse($tokens[1]->startsPhrase());
+        $this->assertTrue($tokens[2]->startsPhrase());
+        $this->assertFalse($tokens[3]->startsPhrase());
+    }
+
+    public function testLegacyPhraseTokensRemainGroupedByBooleanFlag(): void
+    {
+        $tokens = new TokenCollection([
+            new Token(0, 'one', 0, true, false),
+            new Token(1, 'two', 4, true, false),
+        ]);
+
+        $groups = $tokens->phraseGroups();
+
+        $this->assertCount(1, $groups);
+        $this->assertInstanceOf(Phrase::class, $groups[0]);
+        $this->assertSame(['one', 'two'], $groups[0]->allTerms());
+    }
+
     public function testWithoutStopWords(): void
     {
         $tokenizer = new Tokenizer();


### PR DESCRIPTION
Phrase tokens now retain whether they start a new phrase, allowing separate quoted phrases to match independently while preserving word order and adjacency within each phrase.